### PR TITLE
Vslvm unallocated

### DIFF
--- a/bindings/java/jni/auto_db_java.cpp
+++ b/bindings/java/jni/auto_db_java.cpp
@@ -1867,26 +1867,25 @@ TSK_RETVAL_ENUM TskAutoDbJava::getVsByFsId(int64_t objId, TSK_DB_VS_INFO & vsDbI
                             vsDbInfo.vstype = curVsDbInfo->vstype;
                             vsDbInfo.offset = curVsDbInfo->offset;
                             return TSK_OK;                            
-                        }                    
+                        }
                     }
-                    tsk_error_set_errstr("TskAutoDbJava:: GetVsByFsId: error getting VS from FS. (Parent VS not Found).");          
-                    tsk_error_set_errno(TSK_ERR_AUTO);      
-                    registerError();  
+                    if (tsk_verbose) {
+                        tsk_fprintf(stderr, "TskAutoDb:: GetVsByFsId: error getting VS from FS. (Parent VS not Found)");        
+                    }
                     return TSK_ERR;
                 }
             }
         } 
-        tsk_error_set_errstr("TskAutoDbJava:: GetVsByFsId: error getting VS from FS (Parent VS Part not found).");
-        tsk_error_set_errstr2("cache size: %" PRIdOFF, m_savedVsPartInfo.size());
-        tsk_error_set_errno(TSK_ERR_AUTO);
-        registerError();                    
+        if (tsk_verbose) {
+                tsk_fprintf(stderr, "TskAutoDb:: GetVsByFsId: error getting VS from FS (Parent VS_Part not found)");
+        }                   
         return TSK_ERR;    
     }
     else {
-    tsk_error_set_errstr("TskAutoDbJava:: GetVsByFsId: error getting VS from FS (FS object not found).");     
-    tsk_error_set_errno(TSK_ERR_AUTO);          
-    registerError();
-    return TSK_ERR; 
+        if (tsk_verbose) {
+                tsk_fprintf(stderr, "TskAutoDb:: GetVsByFsId: error getting VS from FS (FS object not found)\n");
+        }
+        return TSK_ERR;
     }
 }
 
@@ -1909,17 +1908,16 @@ TSK_RETVAL_ENUM TskAutoDbJava::addUnallocFsSpaceToDb(size_t & numFs) {
     for (vector<TSK_DB_FS_INFO>::iterator curFsDbInfo = m_savedFsInfo.begin(); curFsDbInfo!= m_savedFsInfo.end(); ++curFsDbInfo) {
         if (m_stopAllProcessing) 
             break;
-        
         // finds VS related to the FS
         TSK_DB_VS_INFO curVsDbInfo; 
         if(getVsByFsId(curFsDbInfo->objId, curVsDbInfo) == TSK_ERR){
-            tsk_error_set_errstr2(
-                      "TskAutoDbJava::addUnallocFsSpaceToDb: error getting VS from FS."
-                      ); 
-            tsk_error_set_errno(TSK_ERR_AUTO);               
-            registerError();
-            //allFsProcessRet = TSK_STOP;
-            return TSK_ERR;
+            // FS is not inside a VS
+            if (tsk_verbose) {
+                tsk_fprintf(stderr, "TskAutoDbJava::addUnallocFsSpaceToDb: FS not inside a VS, adding the unnalocated space\n");
+            }
+            TSK_RETVAL_ENUM retval = addFsInfoUnalloc(m_img_info, *curFsDbInfo);
+            if (retval == TSK_ERR)
+                    allFsProcessRet = TSK_ERR;
         }        
         else {
             if ((curVsDbInfo.vstype == TSK_VS_TYPE_APFS)||(curVsDbInfo.vstype == TSK_VS_TYPE_LVM)){ 
@@ -2012,7 +2010,7 @@ TSK_RETVAL_ENUM TskAutoDbJava::addUnallocFsSpaceToDb(size_t & numFs) {
                     const auto pool = tsk_pool_open_img_sing(m_img_info, curVsDbInfo.offset, TSK_POOL_TYPE_LVM);
                     if (pool == nullptr) {
                         tsk_error_set_errstr2(
-                        "findFilesInPool: Error opening pool");
+                        "TskAutoDbJava::addUnallocFsSpaceToDb: Error opening pool");
                         registerError();
                         allFsProcessRet = TSK_ERR;
                     }
@@ -2034,7 +2032,7 @@ TSK_RETVAL_ENUM TskAutoDbJava::addUnallocFsSpaceToDb(size_t & numFs) {
                             tsk_img_close(pool_vol_img);
                             tsk_pool_close(pool);
                             tsk_error_set_errstr2(
-                                "findFilesInPool: Unable to open file system in LVM logical volume: %" PRIdOFF "",
+                                "TskAutoDbJava::addUnallocFsSpaceToDb: Unable to open file system in LVM logical volume: %" PRIdOFF "",
                                 curFsDbInfo->imgOffset);
                             tsk_error_set_errno(TSK_ERR_FS);
                             registerError();

--- a/bindings/java/jni/auto_db_java.cpp
+++ b/bindings/java/jni/auto_db_java.cpp
@@ -289,12 +289,40 @@ TskAutoDbJava::addPoolInfoAndVS(const TSK_POOL_INFO *pool_info, int64_t parObjId
     }
     saveObjectInfo(poolObjId, parObjId, TSK_DB_OBJECT_TYPE_POOL);
 
-    // Add the pool volume
-    jlong objIdj = m_jniEnv->CallLongMethod(m_javaDbObj, m_addVolumeSystemMethodID,
-        poolObjIdj, TSK_VS_TYPE_APFS, pool_info->img_offset, (uint64_t)pool_info->block_size);
-    objId = (int64_t)objIdj;
 
-    saveObjectInfo(objId, poolObjId, TSK_DB_OBJECT_TYPE_VS);
+
+
+    if (pool_info->ctype == TSK_POOL_TYPE_APFS){
+        // Add the APFS pool volume
+        jlong objIdj = m_jniEnv->CallLongMethod(m_javaDbObj, m_addVolumeSystemMethodID,
+            poolObjIdj, TSK_VS_TYPE_APFS, pool_info->img_offset, (uint64_t)pool_info->block_size);
+        objId = (int64_t)objIdj;
+
+        // populating cache m_savedVsInfo and ObjectInfo
+        TSK_DB_VS_INFO vs_db;
+        vs_db.objId = objId;
+        vs_db.offset = pool_info->img_offset;
+        vs_db.vstype = TSK_VS_TYPE_APFS;
+        vs_db.block_size = pool_info->block_size;
+        m_savedVsInfo.push_back(vs_db);
+        saveObjectInfo(objId, poolObjId, TSK_DB_OBJECT_TYPE_VS);
+    } 
+    if (pool_info->ctype == TSK_POOL_TYPE_LVM){
+        // Add the APFS pool volume
+        jlong objIdj = m_jniEnv->CallLongMethod(m_javaDbObj, m_addVolumeSystemMethodID,
+            poolObjIdj, TSK_VS_TYPE_LVM, pool_info->img_offset, (uint64_t)pool_info->block_size);
+        objId = (int64_t)objIdj;
+
+        // populating cache m_savedVsInfo and objectInfo
+        TSK_DB_VS_INFO vs_db;
+        vs_db.objId = objId;
+        vs_db.offset = pool_info->img_offset;
+        vs_db.vstype = TSK_VS_TYPE_LVM;
+        vs_db.block_size = pool_info->block_size;
+        m_savedVsInfo.push_back(vs_db);
+        saveObjectInfo(objId, poolObjId, TSK_DB_OBJECT_TYPE_VS);
+    } 
+
     return TSK_OK;
 }
 
@@ -321,7 +349,21 @@ TskAutoDbJava::addPoolVolumeInfo(const TSK_POOL_VOLUME_INFO* pool_vol,
         return TSK_ERR;
     }
 
+
+    // here we add pool vol into available vs_part fields
+    TSK_DB_VS_PART_INFO vol_info_db;
+    vol_info_db.objId = objId; ///< set to 0 if unknown (before it becomes a db object)  
+    // pool_vol_info_db.tag = ;  ///< Set to TSK_POOL_VOLUME_INFO_TAG when struct is alloc
+    // vol_info_db. = pool_vol->index;     ///< Index of Volume
+    snprintf(vol_info_db.desc, TSK_MAX_DB_VS_PART_INFO_DESC_LEN - 1, "%s", pool_vol->desc);   ///< Description
+    //pool_vol_info_db.password_hint = ;                 ///< Password hint for encrypted volumes
+    vol_info_db.start = pool_vol->block;                      ///< Starting Block number
+    //vol_info_db.len = pool_vol->;                 ///< Number of blocks in the volume
+    //vol_info_db.flags = pool_vol->flags;  //flags are not compatible
+    m_savedVsPartInfo.push_back(vol_info_db);
+
     saveObjectInfo(objId, parObjId, TSK_DB_OBJECT_TYPE_VOL);
+
     return TSK_OK;
 }
 
@@ -1195,7 +1237,7 @@ TskAutoDbJava::addUnallocatedPoolBlocksToDb(size_t & numPool) {
         if (m_poolOffsetToVsId.find(pool_info->img_offset) == m_poolOffsetToVsId.end()) {
             tsk_error_reset();
             tsk_error_set_errno(TSK_ERR_AUTO_DB);
-            tsk_error_set_errstr("Error addUnallocatedPoolBlocksToDb() - could not find volume system object ID for pool at offset %lld", pool_info->img_offset);
+            tsk_error_set_errstr("Error addUnallocatedPoolBlocksToDb() - could not find volume system object ID for pool at offset %lld", (long long int)pool_info->img_offset);
             return TSK_ERR;
         }
         int64_t curPoolVs = m_poolOffsetToVsId[pool_info->img_offset];
@@ -1703,7 +1745,7 @@ TSK_WALK_RET_ENUM TskAutoDbJava::fsWalkUnallocBlocksCb(const TSK_FS_BLOCK *a_blo
 * @param dbFsInfo fs to process
 * @returns TSK_OK on success, TSK_ERR on error
 */
-TSK_RETVAL_ENUM TskAutoDbJava::addFsInfoUnalloc(const TSK_DB_FS_INFO & dbFsInfo) {
+TSK_RETVAL_ENUM TskAutoDbJava::addFsInfoUnalloc(const TSK_IMG_INFO*  curImgInfo, const TSK_DB_FS_INFO & dbFsInfo) {
 
     // Unalloc space is handled separately for APFS
     if (dbFsInfo.fType == TSK_FS_TYPE_APFS) {
@@ -1711,9 +1753,10 @@ TSK_RETVAL_ENUM TskAutoDbJava::addFsInfoUnalloc(const TSK_DB_FS_INFO & dbFsInfo)
     }
 
     //open the fs we have from database
-    TSK_FS_INFO * fsInfo = tsk_fs_open_img(m_img_info, dbFsInfo.imgOffset, dbFsInfo.fType);
+    TSK_FS_INFO * fsInfo = tsk_fs_open_img((TSK_IMG_INFO*)curImgInfo, dbFsInfo.imgOffset, dbFsInfo.fType); 
     if (fsInfo == NULL) {
         tsk_error_set_errstr2("TskAutoDbJava::addFsInfoUnalloc: error opening fs at offset %" PRIdOFF, dbFsInfo.imgOffset);
+        tsk_error_set_errno(TSK_ERR_AUTO);
         registerError();
         return TSK_ERR;
     }
@@ -1721,6 +1764,7 @@ TSK_RETVAL_ENUM TskAutoDbJava::addFsInfoUnalloc(const TSK_DB_FS_INFO & dbFsInfo)
     //create a "fake" dir to hold the unalloc files for the fs
     if (addUnallocFsBlockFilesParent(dbFsInfo.objId, m_curUnallocDirId, m_curImgId) == TSK_ERR) {
         tsk_error_set_errstr2("addFsInfoUnalloc: error creating dir for unallocated space");
+        tsk_error_set_errno(TSK_ERR_AUTO);
         registerError();
         return TSK_ERR;
     }
@@ -1737,6 +1781,7 @@ TSK_RETVAL_ENUM TskAutoDbJava::addFsInfoUnalloc(const TSK_DB_FS_INFO & dbFsInfo)
         errss << "TskAutoDbJava::addFsInfoUnalloc: error walking fs unalloc blocks, fs id: ";
         errss << unallocBlockWlkTrack.fsObjId;
         tsk_error_set_errstr2("%s", errss.str().c_str());
+        tsk_error_set_errno(TSK_ERR_AUTO);
         registerError();
         return TSK_ERR;
     }
@@ -1754,6 +1799,9 @@ TSK_RETVAL_ENUM TskAutoDbJava::addFsInfoUnalloc(const TSK_DB_FS_INFO & dbFsInfo)
     int64_t fileObjId = 0;
 
     if (addUnallocBlockFile(m_curUnallocDirId, dbFsInfo.objId, unallocBlockWlkTrack.size, unallocBlockWlkTrack.ranges, fileObjId, m_curImgId) == TSK_ERR) {
+        tsk_error_set_errstr2("addFsInfoUnalloc: error addUnallocBlockFile");
+        tsk_error_set_errno(TSK_ERR_AUTO);
+        registerError();
         registerError();
         tsk_fs_close(fsInfo);
         return TSK_ERR;
@@ -1777,7 +1825,7 @@ TSK_RETVAL_ENUM TskAutoDbJava::addUnallocSpaceToDb() {
     size_t numVsP = 0;
     size_t numFs = 0;
     size_t numPool = 0;
-
+    
     TSK_RETVAL_ENUM retFsSpace = addUnallocFsSpaceToDb(numFs);
     TSK_RETVAL_ENUM retVsSpace = addUnallocVsSpaceToDb(numVsP);
     TSK_RETVAL_ENUM retPoolSpace = addUnallocatedPoolBlocksToDb(numPool);
@@ -1796,31 +1844,242 @@ TSK_RETVAL_ENUM TskAutoDbJava::addUnallocSpaceToDb() {
 }
 
 
+TSK_RETVAL_ENUM TskAutoDbJava::getVsPartById(int64_t objId, TSK_VS_PART_INFO & vsPartInfo){
+    for (vector<TSK_DB_VS_PART_INFO>::iterator curVsPartDbInfo = m_savedVsPartInfo.begin(); curVsPartDbInfo!= m_savedVsPartInfo.end(); ++curVsPartDbInfo) {
+        if (curVsPartDbInfo->objId == objId){
+            vsPartInfo.start = curVsPartDbInfo->start;
+            vsPartInfo.desc = curVsPartDbInfo->desc;
+            vsPartInfo.flags = curVsPartDbInfo->flags;
+            vsPartInfo.len = curVsPartDbInfo->len;   
+
+            return TSK_OK;
+        }
+    }
+    return TSK_ERR;
+}
+
+TSK_RETVAL_ENUM TskAutoDbJava::getVsByFsId(int64_t objId, TSK_DB_VS_INFO & vsDbInfo){    
+    TSK_DB_OBJECT* fsObjDbInfo = NULL;
+    if ( getObjectInfo( objId, &fsObjDbInfo) == TSK_OK){ //searches for fs object
+        for (vector<TSK_DB_VS_PART_INFO>::iterator curVsPartDbInfo = m_savedVsPartInfo.begin(); curVsPartDbInfo!= m_savedVsPartInfo.end(); ++curVsPartDbInfo) { //searches for vspart parent of fs
+            if (fsObjDbInfo->parObjId == curVsPartDbInfo->objId){
+                TSK_DB_OBJECT* vsPartObjDbInfo = NULL;
+                if ( getObjectInfo(curVsPartDbInfo->objId, &vsPartObjDbInfo ) == TSK_OK){
+                    for (vector<TSK_DB_VS_INFO>::iterator curVsDbInfo = m_savedVsInfo.begin(); curVsDbInfo!= m_savedVsInfo.end(); ++curVsDbInfo) { //searches for vs parent of vspart
+                        if (vsPartObjDbInfo->parObjId == curVsDbInfo->objId){
+                            vsDbInfo.objId = curVsDbInfo->objId;
+                            vsDbInfo.block_size = curVsDbInfo->block_size;
+                            vsDbInfo.vstype = curVsDbInfo->vstype;
+                            vsDbInfo.offset = curVsDbInfo->offset;
+                            return TSK_OK;                            
+                        }                    
+                    }
+                    tsk_error_set_errstr("TskAutoDbJava:: GetVsByFsId: error getting VS from FS. (Parent VS not Found).");          
+                    tsk_error_set_errno(TSK_ERR_AUTO);      
+                    registerError();  
+                    return TSK_ERR;
+                }
+            }
+        } 
+        tsk_error_set_errstr("TskAutoDbJava:: GetVsByFsId: error getting VS from FS (Parent VS Part not found).");
+        tsk_error_set_errstr2("cache size: %" PRIdOFF, m_savedVsPartInfo.size());
+        tsk_error_set_errno(TSK_ERR_AUTO);
+        registerError();                    
+        return TSK_ERR;    
+    }
+    else {
+    tsk_error_set_errstr("TskAutoDbJava:: GetVsByFsId: error getting VS from FS (FS object not found).");     
+    tsk_error_set_errno(TSK_ERR_AUTO);          
+    registerError();
+    return TSK_ERR; 
+    }
+}
+
+
 /**
 * Process each file system in the database and add its unallocated sectors to virtual files. 
 * @param numFs (out) number of filesystems found
 * @returns TSK_OK on success, TSK_ERR on error (if some or all fs could not be processed)
 */
 TSK_RETVAL_ENUM TskAutoDbJava::addUnallocFsSpaceToDb(size_t & numFs) {
-
+    
     if(m_stopAllProcessing) {
         return TSK_OK;
     }
 
-    numFs = m_savedFsInfo.size();
+    numFs = m_savedFsInfo.size();     
     TSK_RETVAL_ENUM allFsProcessRet = TSK_OK;
-    for (vector<TSK_DB_FS_INFO>::iterator it = m_savedFsInfo.begin(); it!= m_savedFsInfo.end(); ++it) {
-        if (m_stopAllProcessing) {
+    
+
+    for (vector<TSK_DB_FS_INFO>::iterator curFsDbInfo = m_savedFsInfo.begin(); curFsDbInfo!= m_savedFsInfo.end(); ++curFsDbInfo) {
+        if (m_stopAllProcessing) 
             break;
+        
+        // finds VS related to the FS
+        TSK_DB_VS_INFO curVsDbInfo; 
+        if(getVsByFsId(curFsDbInfo->objId, curVsDbInfo) == TSK_ERR){
+            tsk_error_set_errstr2(
+                      "TskAutoDbJava::addUnallocFsSpaceToDb: error getting VS from FS."
+                      ); 
+            tsk_error_set_errno(TSK_ERR_AUTO);               
+            registerError();
+            //allFsProcessRet = TSK_STOP;
+            return TSK_ERR;
+        }        
+        else {
+            if ((curVsDbInfo.vstype == TSK_VS_TYPE_APFS)||(curVsDbInfo.vstype == TSK_VS_TYPE_LVM)){ 
+                
+                TSK_DB_OBJECT* fsObjInfo = NULL;
+                if (getObjectInfo ( curFsDbInfo->objId, &fsObjInfo) == TSK_ERR ) {
+                    tsk_error_set_errstr(
+                            "TskAutoDbJava::addUnallocFsSpaceToDb: error getting Object by ID"
+                            );              
+                    tsk_error_set_errno(TSK_ERR_AUTO);  
+                    registerError();
+                    return TSK_ERR;
+
+                } 
+                
+                TSK_VS_PART_INFO curVsPartInfo;
+                if (getVsPartById(fsObjInfo->parObjId, curVsPartInfo) == TSK_ERR){
+                    tsk_error_set_errstr(
+                        "TskAutoDbJava::addUnallocFsSpaceToDb: error getting Volume Part from FSInfo"
+                        );              
+                    tsk_error_set_errno(TSK_ERR_AUTO);  
+                    registerError();
+                    return TSK_ERR;
+                }
+                
+                
+ 
+
+                if (curVsDbInfo.vstype == TSK_VS_TYPE_APFS) {      
+                        const auto pool = tsk_pool_open_img_sing(m_img_info, curVsDbInfo.offset, TSK_POOL_TYPE_APFS);
+                        if (pool == nullptr) {
+                            tsk_error_set_errstr2(
+                                "TskAutoDbJava::addUnallocFsSpaceToDb:: Error opening pool. ");
+                            tsk_error_set_errstr2("Offset: %" PRIdOFF, curVsDbInfo.offset);
+                            registerError();
+                            allFsProcessRet = TSK_ERR;
+                        }
+                        const auto pool_vol_img = pool->get_img_info(pool, curVsPartInfo.start);
+                            
+                        if (pool_vol_img != NULL) {
+                            TSK_FS_INFO *fs_info = apfs_open(pool_vol_img, 0, TSK_FS_TYPE_APFS, "");
+                            if (fs_info) {     
+                                TSK_RETVAL_ENUM retval = addFsInfoUnalloc(pool_vol_img, *curFsDbInfo);
+                                if (retval == TSK_ERR)
+                                                allFsProcessRet = TSK_ERR;
+
+                                tsk_fs_close(fs_info);
+                                tsk_img_close(pool_vol_img);
+
+                                if (retval == TSK_STOP) {
+                                    tsk_pool_close(pool);
+                                    allFsProcessRet = TSK_STOP;
+                                }
+                                
+                                
+                            }
+                            else {
+                                if (curVsPartInfo.flags & TSK_POOL_VOLUME_FLAG_ENCRYPTED) {
+                                    tsk_error_reset();
+                                    tsk_error_set_errno(TSK_ERR_FS_ENCRYPTED);
+                                    tsk_error_set_errstr(
+                                        "TskAutoDbJava::addUnallocFsSpaceToDb: Encrypted APFS file system");
+                                    tsk_error_set_errstr2("Block: %" PRIdOFF, curVsPartInfo.start);
+                                    registerError();
+                                }
+                                else {
+                                    tsk_error_set_errstr2(
+                                        "TskAutoDbJava::addUnallocFsSpaceToDb: Error opening APFS file system");
+                                    registerError();
+                                }
+
+                                tsk_img_close(pool_vol_img);
+                                tsk_pool_close(pool);
+                                allFsProcessRet = TSK_ERR;
+                            }
+                            tsk_img_close(pool_vol_img);
+                        }
+                        else {
+                            tsk_pool_close(pool);
+                            tsk_error_set_errstr2(
+                                "TskAutoDbJava::addUnallocFsSpaceToDb: Error opening APFS pool");
+                            registerError();
+                            allFsProcessRet = TSK_ERR;
+                        }
+                                              
+                }
+                #ifdef HAVE_LIBVSLVM
+                if ( curVsDbInfo.vstype == TSK_VS_TYPE_LVM) { 
+
+                    const auto pool = tsk_pool_open_img_sing(m_img_info, curVsDbInfo.offset, TSK_POOL_TYPE_LVM);
+                    if (pool == nullptr) {
+                        tsk_error_set_errstr2(
+                        "findFilesInPool: Error opening pool");
+                        registerError();
+                        allFsProcessRet = TSK_ERR;
+                    }
+                    
+    
+                    TSK_IMG_INFO *pool_vol_img = pool->get_img_info(pool, curVsPartInfo.start);
+                    if (pool_vol_img == NULL) {                        
+                        tsk_pool_close(pool);                        
+                        tsk_error_set_errstr2(
+                            "TskAutoDbJava::addUnallocFsSpaceToDb: Error opening LVM logical volume: %" PRIdOFF "",
+                            curVsPartInfo.start);
+                        tsk_error_set_errno(TSK_ERR_FS);
+                        registerError();
+                        allFsProcessRet = TSK_ERR;
+                    } 
+                    else {
+                        TSK_FS_INFO *fs_info = tsk_fs_open_img(pool_vol_img, curFsDbInfo->imgOffset, curFsDbInfo->fType);
+                        if (fs_info == NULL) {
+                            tsk_img_close(pool_vol_img);
+                            tsk_pool_close(pool);
+                            tsk_error_set_errstr2(
+                                "findFilesInPool: Unable to open file system in LVM logical volume: %" PRIdOFF "",
+                                curFsDbInfo->imgOffset);
+                            tsk_error_set_errno(TSK_ERR_FS);
+                            registerError();
+                            allFsProcessRet = TSK_ERR;
+                        }
+                        else {
+                            TSK_RETVAL_ENUM retval = addFsInfoUnalloc(pool_vol_img, *curFsDbInfo);
+                            if (retval == TSK_ERR)
+                                allFsProcessRet = TSK_ERR;
+
+                            tsk_fs_close(fs_info);
+                            tsk_img_close(pool_vol_img);
+
+                            if (retval == TSK_STOP) {
+                                tsk_pool_close(pool);
+                                allFsProcessRet = TSK_STOP;
+                            }
+                        }
+                    }
+                    
+                }        
+                #endif /* HAVE_LIBVSLVM */    
+
+                if (curVsDbInfo.vstype == TSK_VS_TYPE_UNSUPP){                                      
+                    tsk_error_set_errstr2(
+                        "TskAutoDbJava::addUnallocFsSpaceToDb: VS Type not supported");
+                    registerError();
+                    allFsProcessRet = TSK_ERR;
+                }
+            }
+            else {
+                if (addFsInfoUnalloc(m_img_info, *curFsDbInfo) == TSK_ERR){
+                    allFsProcessRet = TSK_ERR;
+                }
+            }    
         }
-        if (addFsInfoUnalloc(*it) == TSK_ERR)
-            allFsProcessRet = TSK_ERR;
     }
-
-    //TODO set parent_path for newly created virt dir/file hierarchy for consistency
-
     return allFsProcessRet;
 }
+
 
 /**
 * Process each volume in the database and add its unallocated sectors to virtual files. 
@@ -1934,7 +2193,7 @@ TSK_RETVAL_ENUM TskAutoDbJava::addUnallocImageSpaceToDb() {
 
     const TSK_OFF_T imgSize = getImageSize();
     if (imgSize == -1) {
-        tsk_error_set_errstr("addUnallocImageSpaceToDb: error getting current image size, can't create unalloc block file for the image.");
+        tsk_error_set_errstr("addUnallocImageSpaceToDb: error getting curent image size, can't create unalloc block file for the image.");
         registerError();
         return TSK_ERR;
     }
@@ -1943,7 +2202,8 @@ TSK_RETVAL_ENUM TskAutoDbJava::addUnallocImageSpaceToDb() {
         //add unalloc block file for the entire image
         vector<TSK_DB_FILE_LAYOUT_RANGE> ranges;
         ranges.push_back(tempRange);
-        int64_t fileObjId = 0;
+        // int64_t fileObjId = 0;
+
         if (TSK_ERR == addUnallocBlockFileInChunks(0, imgSize, m_curImgId, m_curImgId)) {
             return TSK_ERR;
         }

--- a/bindings/java/jni/auto_db_java.cpp
+++ b/bindings/java/jni/auto_db_java.cpp
@@ -2027,21 +2027,27 @@ TSK_RETVAL_ENUM TskAutoDbJava::addUnallocFsSpaceToDb(size_t & numFs) {
                         allFsProcessRet = TSK_ERR;
                     } 
                     else {
-                        TSK_FS_INFO *fs_info = tsk_fs_open_img(pool_vol_img, curFsDbInfo->imgOffset, curFsDbInfo->fType);
+                        TSK_FS_INFO *fs_info = tsk_fs_open_img(pool_vol_img, 0, curFsDbInfo->fType);
                         if (fs_info == NULL) {
                             tsk_img_close(pool_vol_img);
                             tsk_pool_close(pool);
                             tsk_error_set_errstr2(
                                 "TskAutoDbJava::addUnallocFsSpaceToDb: Unable to open file system in LVM logical volume: %" PRIdOFF "",
-                                curFsDbInfo->imgOffset);
+                                curVsPartInfo.start);
                             tsk_error_set_errno(TSK_ERR_FS);
                             registerError();
                             allFsProcessRet = TSK_ERR;
                         }
                         else {
                             TSK_RETVAL_ENUM retval = addFsInfoUnalloc(pool_vol_img, *curFsDbInfo);
-                            if (retval == TSK_ERR)
+                            if (retval == TSK_ERR){
+                                tsk_error_set_errstr2(
+                                        "TskAutoDb::addUnallocFsSpaceToDb: Error getting unallocated space");
+                                tsk_error_set_errno(TSK_ERR_FS);
+                                registerError();
                                 allFsProcessRet = TSK_ERR;
+                            }
+
 
                             tsk_fs_close(fs_info);
                             tsk_img_close(pool_vol_img);

--- a/bindings/java/jni/auto_db_java.cpp
+++ b/bindings/java/jni/auto_db_java.cpp
@@ -307,7 +307,7 @@ TskAutoDbJava::addPoolInfoAndVS(const TSK_POOL_INFO *pool_info, int64_t parObjId
         m_savedVsInfo.push_back(vs_db);
         saveObjectInfo(objId, poolObjId, TSK_DB_OBJECT_TYPE_VS);
     } 
-    if (pool_info->ctype == TSK_POOL_TYPE_LVM){
+    else if (pool_info->ctype == TSK_POOL_TYPE_LVM){
         // Add the APFS pool volume
         jlong objIdj = m_jniEnv->CallLongMethod(m_javaDbObj, m_addVolumeSystemMethodID,
             poolObjIdj, TSK_VS_TYPE_LVM, pool_info->img_offset, (uint64_t)pool_info->block_size);
@@ -351,15 +351,11 @@ TskAutoDbJava::addPoolVolumeInfo(const TSK_POOL_VOLUME_INFO* pool_vol,
 
 
     // here we add pool vol into available vs_part fields
+    // some fields were not directly compatible and were not added
     TSK_DB_VS_PART_INFO vol_info_db;
     vol_info_db.objId = objId; ///< set to 0 if unknown (before it becomes a db object)  
-    // pool_vol_info_db.tag = ;  ///< Set to TSK_POOL_VOLUME_INFO_TAG when struct is alloc
-    // vol_info_db. = pool_vol->index;     ///< Index of Volume
     snprintf(vol_info_db.desc, TSK_MAX_DB_VS_PART_INFO_DESC_LEN - 1, "%s", pool_vol->desc);   ///< Description
-    //pool_vol_info_db.password_hint = ;                 ///< Password hint for encrypted volumes
-    vol_info_db.start = pool_vol->block;                      ///< Starting Block number
-    //vol_info_db.len = pool_vol->;                 ///< Number of blocks in the volume
-    //vol_info_db.flags = pool_vol->flags;  //flags are not compatible
+    vol_info_db.start = pool_vol->block; ///< Starting Block number
     m_savedVsPartInfo.push_back(vol_info_db);
 
     saveObjectInfo(objId, parObjId, TSK_DB_OBJECT_TYPE_VOL);
@@ -1237,7 +1233,7 @@ TskAutoDbJava::addUnallocatedPoolBlocksToDb(size_t & numPool) {
         if (m_poolOffsetToVsId.find(pool_info->img_offset) == m_poolOffsetToVsId.end()) {
             tsk_error_reset();
             tsk_error_set_errno(TSK_ERR_AUTO_DB);
-            tsk_error_set_errstr("Error addUnallocatedPoolBlocksToDb() - could not find volume system object ID for pool at offset %lld", (long long int)pool_info->img_offset);
+            tsk_error_set_errstr("Error addUnallocatedPoolBlocksToDb() - could not find volume system object ID for pool at offset %jd", (intptr_t)pool_info->img_offset);
             return TSK_ERR;
         }
         int64_t curPoolVs = m_poolOffsetToVsId[pool_info->img_offset];
@@ -1753,7 +1749,7 @@ TSK_RETVAL_ENUM TskAutoDbJava::addFsInfoUnalloc(const TSK_IMG_INFO*  curImgInfo,
     }
 
     //open the fs we have from database
-    TSK_FS_INFO * fsInfo = tsk_fs_open_img((TSK_IMG_INFO*)curImgInfo, dbFsInfo.imgOffset, dbFsInfo.fType); 
+    TSK_FS_INFO * fsInfo = tsk_fs_open_img((TSK_IMG_INFO*)curImgInfo, dbFsInfo.imgOffset, dbFsInfo.fType);
     if (fsInfo == NULL) {
         tsk_error_set_errstr2("TskAutoDbJava::addFsInfoUnalloc: error opening fs at offset %" PRIdOFF, dbFsInfo.imgOffset);
         tsk_error_set_errno(TSK_ERR_AUTO);
@@ -1802,7 +1798,6 @@ TSK_RETVAL_ENUM TskAutoDbJava::addFsInfoUnalloc(const TSK_IMG_INFO*  curImgInfo,
         tsk_error_set_errstr2("addFsInfoUnalloc: error addUnallocBlockFile");
         tsk_error_set_errno(TSK_ERR_AUTO);
         registerError();
-        registerError();
         tsk_fs_close(fsInfo);
         return TSK_ERR;
     }
@@ -1825,7 +1820,7 @@ TSK_RETVAL_ENUM TskAutoDbJava::addUnallocSpaceToDb() {
     size_t numVsP = 0;
     size_t numFs = 0;
     size_t numPool = 0;
-    
+
     TSK_RETVAL_ENUM retFsSpace = addUnallocFsSpaceToDb(numFs);
     TSK_RETVAL_ENUM retVsSpace = addUnallocVsSpaceToDb(numVsP);
     TSK_RETVAL_ENUM retPoolSpace = addUnallocatedPoolBlocksToDb(numPool);
@@ -1902,12 +1897,12 @@ TSK_RETVAL_ENUM TskAutoDbJava::getVsByFsId(int64_t objId, TSK_DB_VS_INFO & vsDbI
 * @returns TSK_OK on success, TSK_ERR on error (if some or all fs could not be processed)
 */
 TSK_RETVAL_ENUM TskAutoDbJava::addUnallocFsSpaceToDb(size_t & numFs) {
-    
+
     if(m_stopAllProcessing) {
         return TSK_OK;
     }
 
-    numFs = m_savedFsInfo.size();     
+    numFs = m_savedFsInfo.size();
     TSK_RETVAL_ENUM allFsProcessRet = TSK_OK;
     
 

--- a/bindings/java/jni/auto_db_java.h
+++ b/bindings/java/jni/auto_db_java.h
@@ -161,7 +161,7 @@ class TskAutoDbJava :public TskAuto {
     jmethodID m_addLayoutFileRangeMethodID = NULL;
 
     // Cached objects
-    vector<TSK_DB_FS_INFO> m_savedFsInfo;    
+    vector<TSK_DB_FS_INFO> m_savedFsInfo;
     vector<TSK_DB_VS_INFO> m_savedVsInfo;
     vector<TSK_DB_VS_PART_INFO> m_savedVsPartInfo;
     vector<TSK_DB_OBJECT> m_savedObjects;

--- a/bindings/java/jni/auto_db_java.h
+++ b/bindings/java/jni/auto_db_java.h
@@ -161,7 +161,7 @@ class TskAutoDbJava :public TskAuto {
     jmethodID m_addLayoutFileRangeMethodID = NULL;
 
     // Cached objects
-    vector<TSK_DB_FS_INFO> m_savedFsInfo;
+    vector<TSK_DB_FS_INFO> m_savedFsInfo;    
     vector<TSK_DB_VS_INFO> m_savedVsInfo;
     vector<TSK_DB_VS_PART_INFO> m_savedVsPartInfo;
     vector<TSK_DB_OBJECT> m_savedObjects;
@@ -200,7 +200,7 @@ class TskAutoDbJava :public TskAuto {
 
     TSK_RETVAL_ENUM addUnallocatedPoolBlocksToDb(size_t & numPool);
     static TSK_WALK_RET_ENUM fsWalkUnallocBlocksCb(const TSK_FS_BLOCK *a_block, void *a_ptr);
-    TSK_RETVAL_ENUM addFsInfoUnalloc(const TSK_DB_FS_INFO & dbFsInfo);
+    TSK_RETVAL_ENUM addFsInfoUnalloc(const TSK_IMG_INFO* curImgInfo, const TSK_DB_FS_INFO & dbFsInfo);
     TSK_RETVAL_ENUM addUnallocFsSpaceToDb(size_t & numFs);
     TSK_RETVAL_ENUM addUnallocVsSpaceToDb(size_t & numVsP);
     TSK_RETVAL_ENUM addUnallocImageSpaceToDb();
@@ -235,7 +235,8 @@ class TskAutoDbJava :public TskAuto {
         int64_t dataSourceObjId);
     TSK_RETVAL_ENUM addUnallocFsBlockFilesParent(const int64_t fsObjId, int64_t& objId, int64_t dataSourceObjId);
     TSK_RETVAL_ENUM addUnallocatedPoolVolume(int vol_index, int64_t parObjId, int64_t& objId);
-
+    TSK_RETVAL_ENUM getVsPartById(int64_t objId, TSK_VS_PART_INFO & vsPartInfo);
+    TSK_RETVAL_ENUM getVsByFsId(int64_t objId, TSK_DB_VS_INFO & vsDbInfo);
 };
 
 #endif

--- a/bindings/java/src/org/sleuthkit/datamodel/TskData.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/TskData.java
@@ -581,6 +581,7 @@ public class TskData {
 		TSK_VS_TYPE_MAC(0x0008, "Mac"), ///< Mac partition table NON-NLS
 		TSK_VS_TYPE_GPT(0x0010, "GPT"), ///< GPT partition table NON-NLS
 		TSK_VS_TYPE_APFS(0x0020, "APFS"), ///< APFS pool NON-NLS
+		TSK_VS_TYPE_LVM(0x0030, "LVM"), ///< LVM pool NON-NLS
 		TSK_VS_TYPE_DBFILLER(0x00F0, bundle.getString("TskData.tskVSTypeEnum.fake")), ///< fake partition table type for loaddb (for images that do not have a volume system)
 		TSK_VS_TYPE_UNSUPP(0xFFFF, bundle.getString("TskData.tskVSTypeEnum.unsupported"));    ///< Unsupported
 
@@ -742,6 +743,7 @@ public class TskData {
 	public enum TSK_POOL_TYPE_ENUM {
 		TSK_POOL_TYPE_DETECT(0, "Auto detect"), ///< Use autodetection methods
 		TSK_POOL_TYPE_APFS(1, "APFS Pool"), ///< APFS Pooled Volumes
+		TSK_POOL_TYPE_LVM(2, "LVM Pool"), ///< LVM Pooled Volumes
 		TSK_POOL_TYPE_UNSUPP(0xffff, "Unsupported") ///< Unsupported pool container type
 		;
 

--- a/tools/fstools/blkcalc.cpp
+++ b/tools/fstools/blkcalc.cpp
@@ -262,8 +262,14 @@ main(int argc, char **argv1)
             exit(1);
         }
 
+        TSK_OFF_T offset = imgaddr * img->sector_size;
+#if HAVE_LIBVSLVM
+        if (pool->ctype == TSK_POOL_TYPE_LVM){
+            offset = 0;
+        }
+#endif /* HAVE_LIBVSLVM */
         img = pool->get_img_info(pool, (TSK_DADDR_T)pvol_block);
-        if ((fs = tsk_fs_open_img_decrypt(img, imgaddr * img->sector_size, fstype, password)) == NULL) {
+        if ((fs = tsk_fs_open_img_decrypt(img, offset, fstype, password)) == NULL){
             tsk_error_print(stderr);
             if (tsk_error_get_errno() == TSK_ERR_FS_UNSUPTYPE)
                 tsk_fs_type_print(stderr);

--- a/tools/fstools/blkcat.cpp
+++ b/tools/fstools/blkcat.cpp
@@ -1,10 +1,10 @@
 /*
 ** blkcat
-** The  Sleuth Kit 
+** The  Sleuth Kit
 **
 ** Given an image , block number, and size, display the contents
 ** of the block to stdout.
-** 
+**
 ** Brian Carrier [carrier <at> sleuthkit [dot] org]
 ** Copyright (c) 2006-2011 Brian Carrier, Basis Technology.  All Rights reserved
 ** Copyright (c) 2003-2005 Brian Carrier.  All rights reserved
@@ -323,8 +323,14 @@ main(int argc, char **argv1)
             exit(1);
         }
 
+        TSK_OFF_T offset = imgaddr * img->sector_size;
+#if HAVE_LIBVSLVM
+        if (pool->ctype == TSK_POOL_TYPE_LVM){
+            offset = 0;
+        }
+#endif /* HAVE_LIBVSLVM */
         img = pool->get_img_info(pool, (TSK_DADDR_T)pvol_block);
-        if ((fs = tsk_fs_open_img_decrypt(img, imgaddr * img->sector_size, fstype, password)) == NULL) {
+        if ((fs = tsk_fs_open_img_decrypt(img, offset, fstype, password)) == NULL) {
             tsk_error_print(stderr);
             if (tsk_error_get_errno() == TSK_ERR_FS_UNSUPTYPE)
                 tsk_fs_type_print(stderr);

--- a/tools/fstools/blkls.cpp
+++ b/tools/fstools/blkls.cpp
@@ -3,7 +3,7 @@
 **
 ** Brian Carrier [carrier <at> sleuthkit [dot] org]
 ** Copyright (c) 2006-2011 Brian Carrier, Basis Technology.  All Rights reserved
-** Copyright (c) 2003-2005 Brian Carrier.  All rights reserved 
+** Copyright (c) 2003-2005 Brian Carrier.  All rights reserved
 **
 ** TASK
 ** Copyright (c) 2002 Brian Carrier, @stake Inc.  All rights reserved
@@ -248,8 +248,14 @@ main(int argc, char **argv1)
                 exit(1);
             }
 
+            TSK_OFF_T offset = imgaddr * img->sector_size;
+#if HAVE_LIBVSLVM
+            if (pool->ctype == TSK_POOL_TYPE_LVM){
+                offset = 0;
+            }
+#endif /* HAVE_LIBVSLVM */
             img = pool->get_img_info(pool, (TSK_DADDR_T)pvol_block);
-            if ((fs = tsk_fs_open_img_decrypt(img, imgaddr * img->sector_size, fstype, password)) == NULL) {
+            if ((fs = tsk_fs_open_img_decrypt(img, offset, fstype, password)) == NULL) {
                 tsk_error_print(stderr);
                 if (tsk_error_get_errno() == TSK_ERR_FS_UNSUPTYPE)
                     tsk_fs_type_print(stderr);
@@ -364,8 +370,14 @@ main(int argc, char **argv1)
                 exit(1);
             }
 
+            TSK_OFF_T offset = imgaddr * img->sector_size;
+#if HAVE_LIBVSLVM
+            if (pool->ctype == TSK_POOL_TYPE_LVM){
+                offset = 0;
+            }
+#endif /* HAVE_LIBVSLVM */
             img = pool->get_img_info(pool, (TSK_DADDR_T)pvol_block);
-            if ((fs = tsk_fs_open_img_decrypt(img, imgaddr * img->sector_size, fstype, password)) == NULL) {
+            if ((fs = tsk_fs_open_img_decrypt(img, offset, fstype, password)) == NULL) {
                 tsk_error_print(stderr);
                 if (tsk_error_get_errno() == TSK_ERR_FS_UNSUPTYPE)
                     tsk_fs_type_print(stderr);

--- a/tools/fstools/blkstat.cpp
+++ b/tools/fstools/blkstat.cpp
@@ -1,12 +1,12 @@
 /*
 ** blkstat
-** The Sleuth Kit 
+** The Sleuth Kit
 **
 ** Get the details about a data unit
 **
 ** Brian Carrier [carrier <at> sleuthkit [dot] org]
 ** Copyright (c) 2006-2011 Brian Carrier, Basis Technology.  All Rights reserved
-** Copyright (c) 2003-2005 Brian Carrier.  All rights reserved 
+** Copyright (c) 2003-2005 Brian Carrier.  All rights reserved
 **
 ** TASK
 ** Copyright (c) 2002 Brian Carrier, @stake Inc.  All rights reserved
@@ -200,8 +200,14 @@ main(int argc, char **argv1)
             exit(1);
         }
 
+        TSK_OFF_T offset = imgaddr * img->sector_size;
+#if HAVE_LIBVSLVM
+        if (pool->ctype == TSK_POOL_TYPE_LVM){
+            offset = 0;
+        }
+#endif /* HAVE_LIBVSLVM */
         img = pool->get_img_info(pool, (TSK_DADDR_T)pvol_block);
-        if ((fs = tsk_fs_open_img_decrypt(img, imgaddr * img->sector_size, fstype, password)) == NULL) {
+        if ((fs = tsk_fs_open_img_decrypt(img, offset, fstype, password)) == NULL) {
             tsk_error_print(stderr);
             if (tsk_error_get_errno() == TSK_ERR_FS_UNSUPTYPE)
                 tsk_fs_type_print(stderr);

--- a/tools/fstools/fcat.cpp
+++ b/tools/fstools/fcat.cpp
@@ -1,6 +1,6 @@
 /*
-** fcat 
-** The Sleuth Kit 
+** fcat
+** The Sleuth Kit
 **
 ** Brian Carrier [carrier <at> sleuthkit [dot] org]
 ** Copyright (c) 2012 Brian Carrier, Basis Technology.  All Rights reserved
@@ -214,8 +214,14 @@ main(int argc, char **argv1)
             exit(1);
         }
 
+         TSK_OFF_T offset = imgaddr * img->sector_size;
+#if HAVE_LIBVSLVM
+        if (pool->ctype == TSK_POOL_TYPE_LVM){
+            offset = 0;
+        }
+#endif /* HAVE_LIBVSLVM */
         img = pool->get_img_info(pool, (TSK_DADDR_T)pvol_block);
-        if ((fs = tsk_fs_open_img_decrypt(img, imgaddr * img->sector_size, fstype, password)) == NULL) {
+        if ((fs = tsk_fs_open_img_decrypt(img, offset, fstype, password)) == NULL) {
             tsk_error_print(stderr);
             if (tsk_error_get_errno() == TSK_ERR_FS_UNSUPTYPE)
                 tsk_fs_type_print(stderr);
@@ -239,7 +245,7 @@ main(int argc, char **argv1)
         free(path);
         exit(1);
     }
-    free(path); 
+    free(path);
 
     // @@@ Cannot currently get ADS with this approach
     retval =

--- a/tools/fstools/ffind.cpp
+++ b/tools/fstools/ffind.cpp
@@ -1,12 +1,12 @@
 /*
 ** ffind  (file find)
-** The Sleuth Kit 
+** The Sleuth Kit
 **
 ** Find the file that uses the specified inode (including deleted files)
-** 
+**
 ** Brian Carrier [carrier <at> sleuthkit [dot] org]
 ** Copyright (c) 2006-2011 Brian Carrier, Basis Technology.  All Rights reserved
-** Copyright (c) 2003-2005 Brian Carrier.  All rights reserved 
+** Copyright (c) 2003-2005 Brian Carrier.  All rights reserved
 **
 ** TASK
 ** Copyright (c) 2002 Brian Carrier, @stake Inc.  All rights reserved
@@ -231,8 +231,14 @@ main(int argc, char **argv1)
             exit(1);
         }
 
+        TSK_OFF_T offset = imgaddr * img->sector_size;
+#if HAVE_LIBVSLVM
+        if (pool->ctype == TSK_POOL_TYPE_LVM){
+            offset = 0;
+        }
+#endif /* HAVE_LIBVSLVM */
         img = pool->get_img_info(pool, (TSK_DADDR_T)pvol_block);
-        if ((fs = tsk_fs_open_img_decrypt(img, imgaddr * img->sector_size, fstype, password)) == NULL) {
+        if ((fs = tsk_fs_open_img_decrypt(img, offset, fstype, password)) == NULL) {
             tsk_error_print(stderr);
             if (tsk_error_get_errno() == TSK_ERR_FS_UNSUPTYPE)
                 tsk_fs_type_print(stderr);

--- a/tools/fstools/fls.cpp
+++ b/tools/fstools/fls.cpp
@@ -334,8 +334,14 @@ main(int argc, char **argv1)
             }
             img_parent = img;
 
+            TSK_OFF_T offset = imgaddr * img->sector_size;
+#if HAVE_LIBVSLVM
+            if (pool->ctype == TSK_POOL_TYPE_LVM){
+                offset = 0;
+            }
+#endif /* HAVE_LIBVSLVM */
             img = pool->get_img_info(pool, (TSK_DADDR_T)pvol_block);
-            if ((fs = tsk_fs_open_img_decrypt(img, imgaddr * img->sector_size, fstype, password)) == NULL) {
+            if ((fs = tsk_fs_open_img_decrypt(img, offset, fstype, password)) == NULL) {
                 tsk_error_print(stderr);
                 if (tsk_error_get_errno() == TSK_ERR_FS_UNSUPTYPE)
                     tsk_fs_type_print(stderr);
@@ -390,8 +396,14 @@ main(int argc, char **argv1)
             }
             img_parent = img;
 
+            TSK_OFF_T offset = imgaddr * img->sector_size;
+#if HAVE_LIBVSLVM
+            if (pool->ctype == TSK_POOL_TYPE_LVM){
+                offset = 0;
+            }
+#endif /* HAVE_LIBVSLVM */
             img = pool->get_img_info(pool, (TSK_DADDR_T)pvol_block);
-            if ((fs = tsk_fs_open_img_decrypt(img, imgaddr * img->sector_size, fstype, password)) == NULL) {
+            if ((fs = tsk_fs_open_img_decrypt(img, offset, fstype, password)) == NULL) {
                 tsk_error_print(stderr);
                 if (tsk_error_get_errno() == TSK_ERR_FS_UNSUPTYPE)
                     tsk_fs_type_print(stderr);

--- a/tools/fstools/fsstat.cpp
+++ b/tools/fstools/fsstat.cpp
@@ -210,8 +210,14 @@ main(int argc, char **argv1)
             exit(1);
         }
 
+        TSK_OFF_T offset = imgaddr * img->sector_size;
+#if HAVE_LIBVSLVM
+        if (pool->ctype == TSK_POOL_TYPE_LVM){
+            offset = 0;
+        }
+#endif /* HAVE_LIBVSLVM */
         img = pool->get_img_info(pool, (TSK_DADDR_T)pvol_block);
-        if ((fs = tsk_fs_open_img_decrypt(img, imgaddr * img->sector_size, fstype, password)) == NULL) {
+        if ((fs = tsk_fs_open_img_decrypt(img, offset, fstype, password)) == NULL) {
             tsk_error_print(stderr);
             if (tsk_error_get_errno() == TSK_ERR_FS_UNSUPTYPE)
                 tsk_fs_type_print(stderr);

--- a/tools/fstools/icat.cpp
+++ b/tools/fstools/icat.cpp
@@ -231,7 +231,7 @@ main(int argc, char **argv1)
     }
 
     if (pvol_block == 0) {
-        if ((fs = tsk_fs_open_img_decrypt(img, imgaddr * img->sector_size, 
+        if ((fs = tsk_fs_open_img_decrypt(img, imgaddr * img->sector_size,
                                           fstype, password)) == NULL) {
             tsk_error_print(stderr);
             if (tsk_error_get_errno() == TSK_ERR_FS_UNSUPTYPE)
@@ -249,8 +249,14 @@ main(int argc, char **argv1)
             exit(1);
         }
 
+        TSK_OFF_T offset = imgaddr * img->sector_size;
+#if HAVE_LIBVSLVM
+        if (pool->ctype == TSK_POOL_TYPE_LVM){
+            offset = 0;
+        }
+#endif /* HAVE_LIBVSLVM */
         img = pool->get_img_info(pool, (TSK_DADDR_T)pvol_block);
-        if ((fs = tsk_fs_open_img_decrypt(img, imgaddr * img->sector_size, fstype, password)) == NULL) {
+        if ((fs = tsk_fs_open_img_decrypt(img, offset, fstype, password)) == NULL) {
             tsk_error_print(stderr);
             if (tsk_error_get_errno() == TSK_ERR_FS_UNSUPTYPE)
                 tsk_fs_type_print(stderr);

--- a/tools/fstools/ifind.cpp
+++ b/tools/fstools/ifind.cpp
@@ -3,7 +3,7 @@
 ** The Sleuth Kit
 **
 ** Given an image  and block number, identify which inode it is used by
-** 
+**
 ** Brian Carrier [carrier <at> sleuthkit [dot] org]
 ** Copyright (c) 2006-2011 Brian Carrier, Basis Technology.  All Rights reserved
 ** Copyright (c) 2003-2005 Brian Carrier.  All rights reserved
@@ -291,8 +291,14 @@ main(int argc, char **argv1)
             exit(1);
         }
 
+        TSK_OFF_T offset = imgaddr * img->sector_size;
+#if HAVE_LIBVSLVM
+        if (pool->ctype == TSK_POOL_TYPE_LVM){
+            offset = 0;
+        }
+#endif /* HAVE_LIBVSLVM */
         img = pool->get_img_info(pool, (TSK_DADDR_T)pvol_block);
-        if ((fs = tsk_fs_open_img_decrypt(img, imgaddr * img->sector_size, fstype, password)) == NULL) {
+        if ((fs = tsk_fs_open_img_decrypt(img, offset, fstype, password)) == NULL) {
             tsk_error_print(stderr);
             if (tsk_error_get_errno() == TSK_ERR_FS_UNSUPTYPE)
                 tsk_fs_type_print(stderr);

--- a/tools/fstools/ils.cpp
+++ b/tools/fstools/ils.cpp
@@ -1,14 +1,14 @@
 /*
-** The Sleuth Kit 
+** The Sleuth Kit
 **
 ** Brian Carrier [carrier <at> sleuthkit [dot] org]
 ** Copyright (c) 2006-2011 Brian Carrier, Basis Technology.  All Rights reserved
-** Copyright (c) 2003-2005 Brian Carrier.  All rights reserved 
+** Copyright (c) 2003-2005 Brian Carrier.  All rights reserved
 **
 ** TASK
 ** Copyright (c) 2002 Brian Carrier, @stake Inc.  All rights reserved
-** 
-** Copyright (c) 1997,1998,1999, International Business Machines          
+**
+** Copyright (c) 1997,1998,1999, International Business Machines
 ** Corporation and others. All Rights Reserved.
 */
 
@@ -57,7 +57,7 @@ usage()
     tsk_fprintf(stderr,
         "\t-f fstype: File system type (use '-f list' for supported types)\n");
     tsk_fprintf(stderr,
-        "\t-o imgoffset: The offset of the file system in the image (in sectors)\n");    
+        "\t-o imgoffset: The offset of the file system in the image (in sectors)\n");
     tsk_fprintf(stderr,
         "\t-P pooltype: Pool container type (use '-p list' for supported types)\n");
     tsk_fprintf(stderr,
@@ -367,8 +367,14 @@ main(int argc, char **argv1)
             exit(1);
         }
 
+        TSK_OFF_T offset = imgaddr * img->sector_size;
+#if HAVE_LIBVSLVM
+        if (pool->ctype == TSK_POOL_TYPE_LVM){
+            offset = 0;
+        }
+#endif /* HAVE_LIBVSLVM */
         img = pool->get_img_info(pool, (TSK_DADDR_T)pvol_block);
-        if ((fs = tsk_fs_open_img_decrypt(img, imgaddr * img->sector_size, fstype, password)) == NULL) {
+        if ((fs = tsk_fs_open_img_decrypt(img, offset, fstype, password)) == NULL) {
             tsk_error_print(stderr);
             if (tsk_error_get_errno() == TSK_ERR_FS_UNSUPTYPE)
                 tsk_fs_type_print(stderr);

--- a/tools/fstools/istat.cpp
+++ b/tools/fstools/istat.cpp
@@ -250,7 +250,7 @@ main(int argc, char **argv1)
     }
 
     if (pvol_block == 0) {
-        if ((fs = tsk_fs_open_img_decrypt(img, imgaddr * img->sector_size, 
+        if ((fs = tsk_fs_open_img_decrypt(img, imgaddr * img->sector_size,
                                           fstype, password)) == NULL) {
             tsk_error_print(stderr);
             if (tsk_error_get_errno() == TSK_ERR_FS_UNSUPTYPE)
@@ -268,8 +268,14 @@ main(int argc, char **argv1)
             exit(1);
         }
 
+        TSK_OFF_T offset = imgaddr * img->sector_size;
+#if HAVE_LIBVSLVM
+        if (pool->ctype == TSK_POOL_TYPE_LVM){
+            offset = 0;
+        }
+#endif /* HAVE_LIBVSLVM */
         img = pool->get_img_info(pool, (TSK_DADDR_T)pvol_block);
-        if ((fs = tsk_fs_open_img_decrypt(img, imgaddr * img->sector_size, fstype, password)) == NULL) {
+        if ((fs = tsk_fs_open_img_decrypt(img, offset, fstype, password)) == NULL) {
             tsk_error_print(stderr);
             if (tsk_error_get_errno() == TSK_ERR_FS_UNSUPTYPE)
                 tsk_fs_type_print(stderr);

--- a/tsk/auto/auto.cpp
+++ b/tsk/auto/auto.cpp
@@ -479,16 +479,16 @@ TskAuto::findFilesInPool(TSK_OFF_T start, TSK_POOL_TYPE_ENUM ptype)
             }
 
             if (filterRetval != TSK_FILTER_SKIP) {
-                TSK_IMG_INFO *pool_img = pool->get_img_info(pool, vol_info->block);
-                if (pool_img != NULL) {
-                    TSK_FS_INFO *fs_info = apfs_open(pool_img, 0, TSK_FS_TYPE_APFS, "");
+                TSK_IMG_INFO *pool_vol_img = pool->get_img_info(pool, vol_info->block);
+                if (pool_vol_img != NULL) {
+                    TSK_FS_INFO *fs_info = apfs_open(pool_vol_img, 0, TSK_FS_TYPE_APFS, "");
                     if (fs_info) {
                         TSK_RETVAL_ENUM retval = findFilesInFsInt(fs_info, fs_info->root_inum);
                         tsk_fs_close(fs_info);
 
-                        // TODO: what if retval != TSK_STOP, shouldn't pool_img be closed?
+                        // TODO: what if retval != TSK_STOP, shouldn't pool_vol_img be closed?
                         if (retval == TSK_STOP) {
-                            tsk_img_close(pool_img);
+                            tsk_img_close(pool_vol_img);
                             tsk_pool_close(pool);
                             return TSK_STOP;
                         }
@@ -508,12 +508,12 @@ TskAuto::findFilesInPool(TSK_OFF_T start, TSK_POOL_TYPE_ENUM ptype)
                             registerError();
                         }
 
-                        tsk_img_close(pool_img);
+                        tsk_img_close(pool_vol_img);
                         tsk_pool_close(pool);
                         return TSK_ERR;
                     }
 
-                    tsk_img_close(pool_img);
+                    tsk_img_close(pool_vol_img);
                 }
                 else {
                     tsk_pool_close(pool);
@@ -540,8 +540,8 @@ TskAuto::findFilesInPool(TSK_OFF_T start, TSK_POOL_TYPE_ENUM ptype)
                 return TSK_STOP;
             }
 
-            TSK_IMG_INFO *pool_img = pool->get_img_info(pool, vol_info->block);
-            if (pool_img == NULL) {
+            TSK_IMG_INFO *pool_vol_img = pool->get_img_info(pool, vol_info->block);
+            if (pool_vol_img == NULL) {
                 tsk_pool_close(pool);
                 tsk_error_set_errstr2(
                     "findFilesInPool: Error opening LVM logical volume: %" PRIdOFF "",
@@ -549,9 +549,9 @@ TskAuto::findFilesInPool(TSK_OFF_T start, TSK_POOL_TYPE_ENUM ptype)
                 registerError();
                 return TSK_ERR;
             }
-            TSK_FS_INFO *fs_info = tsk_fs_open_img(pool_img, 0, TSK_FS_TYPE_DETECT);
+            TSK_FS_INFO *fs_info = tsk_fs_open_img(pool_vol_img, 0, TSK_FS_TYPE_DETECT);
             if (fs_info == NULL) {
-                tsk_img_close(pool_img);
+                tsk_img_close(pool_vol_img);
                 tsk_pool_close(pool);
                 tsk_error_set_errstr2(
                     "findFilesInPool: Unable to open file system in LVM logical volume: %" PRIdOFF "",
@@ -562,7 +562,7 @@ TskAuto::findFilesInPool(TSK_OFF_T start, TSK_POOL_TYPE_ENUM ptype)
             TSK_RETVAL_ENUM retval = findFilesInFsInt(fs_info, fs_info->root_inum);
 
             tsk_fs_close(fs_info);
-            tsk_img_close(pool_img);
+            tsk_img_close(pool_vol_img);
 
             if (retval == TSK_STOP) {
                 tsk_pool_close(pool);

--- a/tsk/auto/auto_db.cpp
+++ b/tsk/auto/auto_db.cpp
@@ -1277,26 +1277,23 @@ TSK_RETVAL_ENUM TskAutoDb::getVsByFsId(int64_t objId, TSK_DB_VS_INFO & vsDbInfo)
                             return TSK_OK;                            
                         }                    
                     }
-                    tsk_error_set_errstr("TskAutoDb:: GetVsByFsId: error getting VS from FS. (Parent VS not Found)"); 
-                     tsk_error_set_errstr2("cache size: %" PRIdOFF, m_savedVsInfo.size());         
-                    tsk_error_set_errno(TSK_ERR_AUTO);      
-                    registerError();  
+                    if (tsk_verbose) {
+                        tsk_fprintf(stderr, "TskAutoDb:: GetVsByFsId: error getting VS from FS. (Parent VS not Found)");        
+                    }
                     return TSK_ERR;
                 }
             }
         } 
-        tsk_error_set_errstr("TskAutoDb:: GetVsByFsId: error getting VS from FS (Parent VS_Part not found) cache size: %"
-                             PRIdOFF, m_savedVsPartInfo.size() );
-        tsk_error_set_errstr2("FS ParentObjId: %" PRIdOFF, fsObjDbInfo.parObjId);
-        tsk_error_set_errno(TSK_ERR_AUTO);
-        registerError();                    
+        if (tsk_verbose) {
+                tsk_fprintf(stderr, "TskAutoDb:: GetVsByFsId: error getting VS from FS (Parent VS_Part not found)");
+        }                   
         return TSK_ERR;    
     }
     else {
-    tsk_error_set_errstr("TskAutoDb:: GetVsByFsId: error getting VS from FS (FS object not found)");     
-    tsk_error_set_errno(TSK_ERR_AUTO);          
-    registerError();
-    return TSK_ERR; 
+        if (tsk_verbose) {
+                tsk_fprintf(stderr, "TskAutoDb:: GetVsByFsId: error getting VS from FS (FS object not found)\n");
+        }
+        return TSK_ERR;
     }
 }
 
@@ -1323,13 +1320,13 @@ TSK_RETVAL_ENUM TskAutoDb::addUnallocFsSpaceToDb(size_t & numFs) {
         // finds VS related to the FS
         TSK_DB_VS_INFO curVsDbInfo; 
         if(getVsByFsId(curFsDbInfo->objId, curVsDbInfo) == TSK_ERR){
-            tsk_error_set_errstr2(
-                      "TskAutoDb::addUnallocFsSpaceToDb: error getting VS from FS."
-                      ); 
-            tsk_error_set_errno(TSK_ERR_AUTO);               
-            registerError();
-            //allFsProcessRet = TSK_STOP;
-            return TSK_ERR;
+            // FS is not inside a VS
+            if (tsk_verbose) {
+                tsk_fprintf(stderr, "TskAutoDbJava::addUnallocFsSpaceToDb: FS not inside a VS, adding the unnalocated space\n");
+            }
+            TSK_RETVAL_ENUM retval = addFsInfoUnalloc(m_img_info, *curFsDbInfo);
+            if (retval == TSK_ERR)
+                    allFsProcessRet = TSK_ERR;
         }        
         else {
             if ((curVsDbInfo.vstype == TSK_VS_TYPE_APFS)||(curVsDbInfo.vstype == TSK_VS_TYPE_LVM)){ 

--- a/tsk/auto/auto_db.cpp
+++ b/tsk/auto/auto_db.cpp
@@ -301,6 +301,14 @@ TSK_FILTER_ENUM TskAutoDb::filterVs(const TSK_VS_INFO * vs_info)
         return TSK_FILTER_STOP;
     }
 
+    // populating cache m_savedVsInfo and ObjectInfo
+    TSK_DB_VS_INFO vs_db;
+    vs_db.objId = m_curImgId;
+    vs_db.offset = vs_info->offset;
+    vs_db.vstype = vs_info->vstype;
+    vs_db.block_size = vs_info->block_size;
+    m_savedVsInfo.push_back(vs_db);
+    
     return TSK_FILTER_CONT;
 }
 
@@ -315,6 +323,7 @@ TskAutoDb::filterPool(const TSK_POOL_INFO * pool_info)
             registerError();
             return TSK_FILTER_STOP;
         }
+
         // Save the parent obj ID for the pool
         m_poolOffsetToParentId[pool_info->img_offset] = m_curVolId;
     }
@@ -324,9 +333,22 @@ TskAutoDb::filterPool(const TSK_POOL_INFO * pool_info)
             registerError();
             return TSK_FILTER_STOP;
         }
+
         // Save the parent obj ID for the pool
         m_poolOffsetToParentId[pool_info->img_offset] = m_curImgId;
     }
+
+    // populating cache m_savedVsInfo 
+    TSK_DB_VS_INFO vs_db;
+    vs_db.objId = m_curPoolVs;
+    vs_db.offset = pool_info->img_offset;
+    if (pool_info->ctype == TSK_POOL_TYPE_APFS)
+        vs_db.vstype = TSK_VS_TYPE_APFS;
+    if (pool_info->ctype == TSK_POOL_TYPE_LVM)
+        vs_db.vstype = TSK_VS_TYPE_LVM;    
+    vs_db.block_size = pool_info->block_size;
+    m_savedVsInfo.push_back(vs_db);
+
 
     // Store the volume system object ID for later use
     m_poolOffsetToVsId[pool_info->img_offset] = m_curPoolVs;
@@ -349,7 +371,7 @@ TskAutoDb::addUnallocatedPoolBlocksToDb(size_t & numPool) {
         if (m_poolOffsetToVsId.find(pool_info->img_offset) == m_poolOffsetToVsId.end()) {
             tsk_error_reset();
             tsk_error_set_errno(TSK_ERR_AUTO_DB);
-            tsk_error_set_errstr("Error addUnallocatedPoolBlocksToDb() - could not find volume system object ID for pool at offset %lld", pool_info->img_offset);
+            tsk_error_set_errstr("Error addUnallocatedPoolBlocksToDb() - could not find volume system object ID for pool at offset %lld", (long long int)pool_info->img_offset);
             return TSK_ERR;
         }
         int64_t curPoolVs = m_poolOffsetToVsId[pool_info->img_offset];
@@ -402,6 +424,12 @@ TskAutoDb::filterPoolVol(const TSK_POOL_VOLUME_INFO * pool_vol)
         return TSK_FILTER_STOP;
     }
 
+    TSK_DB_VS_PART_INFO vol_info_db;
+    vol_info_db.objId = m_curPoolVol;   
+    snprintf(vol_info_db.desc, TSK_MAX_DB_VS_PART_INFO_DESC_LEN - 1, "%s", pool_vol->desc);  
+    vol_info_db.start = pool_vol->block;                      ///< Starting Block number
+    m_savedVsPartInfo.push_back(vol_info_db);    
+
     return TSK_FILTER_CONT;
 }
 
@@ -412,10 +440,23 @@ TskAutoDb::filterVol(const TSK_VS_PART_INFO * vs_part)
     m_foundStructure = true;
     m_poolFound = false;
 
+
+
     if (m_db->addVolumeInfo(vs_part, m_curVsId, m_curVolId)) {
         registerError();
         return TSK_FILTER_STOP;
     }
+
+    // Save the volume info for creating unallocated blocks later
+    TSK_DB_VS_PART_INFO vs_part_db;
+    vs_part_db.objId = m_curVolId;
+    vs_part_db.addr = vs_part->addr;
+    vs_part_db.start = vs_part->start;
+    vs_part_db.len = vs_part->len;
+    strncpy(vs_part_db.desc, vs_part->desc, TSK_MAX_DB_VS_PART_INFO_DESC_LEN - 1);
+    vs_part_db.flags = vs_part->flags;
+    m_savedVsPartInfo.push_back(vs_part_db);
+
 
     return TSK_FILTER_CONT;
 }
@@ -471,6 +512,20 @@ TskAutoDb::filterFs(TSK_FS_INFO * fs_info)
     }
 
     setFileFilterFlags(filterFlags);
+
+
+    // Save the file system info for creating unallocated blocks later
+    TSK_DB_FS_INFO fs_info_db;
+    fs_info_db.objId = m_curFsId;
+    fs_info_db.imgOffset = fs_info->offset;
+    fs_info_db.fType = fs_info->ftype;
+    fs_info_db.block_size = fs_info->block_size;
+    fs_info_db.block_count = fs_info->block_count;
+    fs_info_db.root_inum = fs_info->root_inum;
+    fs_info_db.first_inum = fs_info->first_inum;
+    fs_info_db.last_inum = fs_info->last_inum;
+    m_savedFsInfo.push_back(fs_info_db);
+
 
     return TSK_FILTER_CONT;
 }
@@ -1094,7 +1149,7 @@ TSK_WALK_RET_ENUM TskAutoDb::fsWalkUnallocBlocksCb(const TSK_FS_BLOCK *a_block, 
 * @param dbFsInfo fs to process
 * @returns TSK_OK on success, TSK_ERR on error
 */
-TSK_RETVAL_ENUM TskAutoDb::addFsInfoUnalloc(const TSK_DB_FS_INFO & dbFsInfo) {
+TSK_RETVAL_ENUM TskAutoDb::addFsInfoUnalloc(const TSK_IMG_INFO*  curImgInfo, const TSK_DB_FS_INFO & dbFsInfo) {
 
     // Unalloc space is handled separately for APFS
     if (dbFsInfo.fType == TSK_FS_TYPE_APFS) {
@@ -1102,7 +1157,7 @@ TSK_RETVAL_ENUM TskAutoDb::addFsInfoUnalloc(const TSK_DB_FS_INFO & dbFsInfo) {
     }
 
     //open the fs we have from database
-    TSK_FS_INFO * fsInfo = tsk_fs_open_img(m_img_info, dbFsInfo.imgOffset, dbFsInfo.fType);
+    TSK_FS_INFO * fsInfo = tsk_fs_open_img((TSK_IMG_INFO*)curImgInfo, dbFsInfo.imgOffset, dbFsInfo.fType);
     if (fsInfo == NULL) {
         tsk_error_set_errstr2("TskAutoDb::addFsInfoUnalloc: error opening fs at offset %" PRIdOFF, dbFsInfo.imgOffset);
         registerError();
@@ -1192,36 +1247,244 @@ TSK_RETVAL_ENUM TskAutoDb::addUnallocSpaceToDb() {
 * @param numFs (out) number of filesystems found
 * @returns TSK_OK on success, TSK_ERR on error (if some or all fs could not be processed)
 */
+TSK_RETVAL_ENUM TskAutoDb::getVsPartById(int64_t objId, TSK_VS_PART_INFO & vsPartInfo){
+    for (vector<TSK_DB_VS_PART_INFO>::iterator curVsPartDbInfo = m_savedVsPartInfo.begin(); curVsPartDbInfo!= m_savedVsPartInfo.end(); ++curVsPartDbInfo) {
+        if (curVsPartDbInfo->objId == objId){
+            vsPartInfo.start = curVsPartDbInfo->start;
+            vsPartInfo.desc = curVsPartDbInfo->desc;
+            vsPartInfo.flags = curVsPartDbInfo->flags;
+            vsPartInfo.len = curVsPartDbInfo->len;   
+
+            return TSK_OK;
+        }
+    }
+    return TSK_ERR;
+}
+
+TSK_RETVAL_ENUM TskAutoDb::getVsByFsId(int64_t objId, TSK_DB_VS_INFO & vsDbInfo){    
+    TSK_DB_OBJECT fsObjDbInfo;
+    if ( m_db->getObjectInfo( objId, fsObjDbInfo) == TSK_OK){ //searches for fs object
+        for (vector<TSK_DB_VS_PART_INFO>::iterator curVsPartDbInfo = m_savedVsPartInfo.begin(); curVsPartDbInfo!= m_savedVsPartInfo.end(); ++curVsPartDbInfo) { //searches for vspart parent of fs
+            if (fsObjDbInfo.parObjId == curVsPartDbInfo->objId){
+                TSK_DB_OBJECT vsPartObjDbInfo;
+                if ( m_db->getObjectInfo(curVsPartDbInfo->objId, vsPartObjDbInfo ) == TSK_OK){
+                    for (vector<TSK_DB_VS_INFO>::iterator curVsDbInfo = m_savedVsInfo.begin(); curVsDbInfo!= m_savedVsInfo.end(); ++curVsDbInfo) { //searches for vs parent of vspart
+                        if (vsPartObjDbInfo.parObjId == curVsDbInfo->objId){
+                            vsDbInfo.objId = curVsDbInfo->objId;
+                            vsDbInfo.block_size = curVsDbInfo->block_size;
+                            vsDbInfo.vstype = curVsDbInfo->vstype;
+                            vsDbInfo.offset = curVsDbInfo->offset;
+                            return TSK_OK;                            
+                        }                    
+                    }
+                    tsk_error_set_errstr("TskAutoDb:: GetVsByFsId: error getting VS from FS. (Parent VS not Found)"); 
+                     tsk_error_set_errstr2("cache size: %" PRIdOFF, m_savedVsInfo.size());         
+                    tsk_error_set_errno(TSK_ERR_AUTO);      
+                    registerError();  
+                    return TSK_ERR;
+                }
+            }
+        } 
+        tsk_error_set_errstr("TskAutoDb:: GetVsByFsId: error getting VS from FS (Parent VS_Part not found) cache size: %"
+                             PRIdOFF, m_savedVsPartInfo.size() );
+        tsk_error_set_errstr2("FS ParentObjId: %" PRIdOFF, fsObjDbInfo.parObjId);
+        tsk_error_set_errno(TSK_ERR_AUTO);
+        registerError();                    
+        return TSK_ERR;    
+    }
+    else {
+    tsk_error_set_errstr("TskAutoDb:: GetVsByFsId: error getting VS from FS (FS object not found)");     
+    tsk_error_set_errno(TSK_ERR_AUTO);          
+    registerError();
+    return TSK_ERR; 
+    }
+}
+
+
+/**
+* Process each file system in the database and add its unallocated sectors to virtual files. 
+* @param numFs (out) number of filesystems found
+* @returns TSK_OK on success, TSK_ERR on error (if some or all fs could not be processed)
+*/
 TSK_RETVAL_ENUM TskAutoDb::addUnallocFsSpaceToDb(size_t & numFs) {
-
-    vector<TSK_DB_FS_INFO> fsInfos;
-
+    
     if(m_stopAllProcessing) {
         return TSK_OK;
     }
 
-    uint16_t ret = m_db->getFsInfos(m_curImgId, fsInfos);
-    if (ret) {
-        tsk_error_set_errstr2("addUnallocFsSpaceToDb: error getting fs infos from db");
-        registerError();
-        return TSK_ERR;
-    }
-
-    numFs = fsInfos.size();
-
+    numFs = m_savedFsInfo.size();     
     TSK_RETVAL_ENUM allFsProcessRet = TSK_OK;
-    for (vector<TSK_DB_FS_INFO>::iterator it = fsInfos.begin(); it!= fsInfos.end(); ++it) {
-        if (m_stopAllProcessing) {
+    
+
+    for (vector<TSK_DB_FS_INFO>::iterator curFsDbInfo = m_savedFsInfo.begin(); curFsDbInfo!= m_savedFsInfo.end(); ++curFsDbInfo) {
+        if (m_stopAllProcessing) 
             break;
+        
+        // finds VS related to the FS
+        TSK_DB_VS_INFO curVsDbInfo; 
+        if(getVsByFsId(curFsDbInfo->objId, curVsDbInfo) == TSK_ERR){
+            tsk_error_set_errstr2(
+                      "TskAutoDb::addUnallocFsSpaceToDb: error getting VS from FS."
+                      ); 
+            tsk_error_set_errno(TSK_ERR_AUTO);               
+            registerError();
+            //allFsProcessRet = TSK_STOP;
+            return TSK_ERR;
+        }        
+        else {
+            if ((curVsDbInfo.vstype == TSK_VS_TYPE_APFS)||(curVsDbInfo.vstype == TSK_VS_TYPE_LVM)){ 
+                
+                TSK_DB_OBJECT fsObjInfo;
+                if (m_db->getObjectInfo ( curFsDbInfo->objId, fsObjInfo) == TSK_ERR ) {
+                    tsk_error_set_errstr(
+                            "TskAutoDb::addUnallocFsSpaceToDb: error getting Object by ID"
+                            );              
+                    tsk_error_set_errno(TSK_ERR_AUTO);  
+                    registerError();
+                    return TSK_ERR;
+
+                } 
+                
+                TSK_VS_PART_INFO curVsPartInfo;
+                if (getVsPartById(fsObjInfo.parObjId, curVsPartInfo) == TSK_ERR){
+                    tsk_error_set_errstr(
+                        "TskAutoDb::addUnallocFsSpaceToDb: error getting Volume Part from FSInfo"
+                        );              
+                    tsk_error_set_errno(TSK_ERR_AUTO);  
+                    registerError();
+                    return TSK_ERR;
+                }
+                
+                
+ 
+
+                if (curVsDbInfo.vstype == TSK_VS_TYPE_APFS) {      
+                        const auto pool = tsk_pool_open_img_sing(m_img_info, curVsDbInfo.offset, TSK_POOL_TYPE_APFS);
+                        if (pool == nullptr) {
+                            tsk_error_set_errstr2(
+                                "TskAutoDb::addUnallocFsSpaceToDb:: Error opening pool. ");
+                            tsk_error_set_errstr2("Offset: %" PRIdOFF, curVsDbInfo.offset);
+                            registerError();
+                            allFsProcessRet = TSK_ERR;
+                        }
+                        const auto pool_img = pool->get_img_info(pool, curVsPartInfo.start);
+                            
+                        if (pool_img != NULL) {
+                            TSK_FS_INFO *fs_info = apfs_open(pool_img, 0, TSK_FS_TYPE_APFS, "");
+                            if (fs_info) {     
+                                TSK_RETVAL_ENUM retval = addFsInfoUnalloc(pool_img, *curFsDbInfo);
+                                if (retval == TSK_ERR)
+                                                allFsProcessRet = TSK_ERR;
+
+                                tsk_fs_close(fs_info);
+                                tsk_img_close(pool_img);
+
+                                if (retval == TSK_STOP) {
+                                    tsk_pool_close(pool);
+                                    allFsProcessRet = TSK_STOP;
+                                }
+                                
+                                
+                            }
+                            else {
+                                if (curVsPartInfo.flags & TSK_POOL_VOLUME_FLAG_ENCRYPTED) {
+                                    tsk_error_reset();
+                                    tsk_error_set_errno(TSK_ERR_FS_ENCRYPTED);
+                                    tsk_error_set_errstr(
+                                        "TskAutoDb::addUnallocFsSpaceToDb: Encrypted APFS file system");
+                                    tsk_error_set_errstr2("Block: %" PRIdOFF, curVsPartInfo.start);
+                                    registerError();
+                                }
+                                else {
+                                    tsk_error_set_errstr2(
+                                        "TskAutoDb::addUnallocFsSpaceToDb: Error opening APFS file system");
+                                    registerError();
+                                }
+
+                                tsk_img_close(pool_img);
+                                tsk_pool_close(pool);
+                                allFsProcessRet = TSK_ERR;
+                            }
+                            tsk_img_close(pool_img);
+                        }
+                        else {
+                            tsk_pool_close(pool);
+                            tsk_error_set_errstr2(
+                                "TskAutoDb::addUnallocFsSpaceToDb: Error opening APFS pool");
+                            registerError();
+                            allFsProcessRet = TSK_ERR;
+                        }
+                                              
+                }
+                #ifdef HAVE_LIBVSLVM
+                if ( curVsDbInfo.vstype == TSK_VS_TYPE_LVM) { 
+
+                    const auto pool = tsk_pool_open_img_sing(m_img_info, curVsDbInfo.offset, TSK_POOL_TYPE_LVM);
+                    if (pool == nullptr) {
+                        tsk_error_set_errstr2(
+                        "findFilesInPool: Error opening pool");
+                        registerError();
+                        allFsProcessRet = TSK_ERR;
+                    }
+                    
+    
+                    TSK_IMG_INFO *pool_img = pool->get_img_info(pool, curVsPartInfo.start);
+                    if (pool_img == NULL) {                        
+                        tsk_pool_close(pool);                        
+                        tsk_error_set_errstr2(
+                            "TskAutoDb::addUnallocFsSpaceToDb: Error opening LVM logical volume: %" PRIdOFF "",
+                            curVsPartInfo.start);
+                        tsk_error_set_errno(TSK_ERR_FS);
+                        registerError();
+                        allFsProcessRet = TSK_ERR;
+                    } 
+                    else {
+                        TSK_FS_INFO *fs_info = tsk_fs_open_img(pool_img, curFsDbInfo->imgOffset, curFsDbInfo->fType);
+                        if (fs_info == NULL) {
+                            tsk_img_close(pool_img);
+                            tsk_pool_close(pool);
+                            tsk_error_set_errstr2(
+                                "findFilesInPool: Unable to open file system in LVM logical volume: %" PRIdOFF "",
+                                curFsDbInfo->imgOffset);
+                            tsk_error_set_errno(TSK_ERR_FS);
+                            registerError();
+                            allFsProcessRet = TSK_ERR;
+                        }
+                        else {
+                            TSK_RETVAL_ENUM retval = addFsInfoUnalloc(pool_img, *curFsDbInfo);
+                            if (retval == TSK_ERR)
+                                allFsProcessRet = TSK_ERR;
+
+                            tsk_fs_close(fs_info);
+                            tsk_img_close(pool_img);
+
+                            if (retval == TSK_STOP) {
+                                tsk_pool_close(pool);
+                                allFsProcessRet = TSK_STOP;
+                            }
+                        }
+                    }
+                    
+                }        
+                #endif /* HAVE_LIBVSLVM */    
+
+                if (curVsDbInfo.vstype == TSK_VS_TYPE_UNSUPP){                                      
+                    tsk_error_set_errstr2(
+                        "TskAutoDb::addUnallocFsSpaceToDb: VS Type not supported");
+                    registerError();
+                    allFsProcessRet = TSK_ERR;
+                }
+            }
+            else {
+                if (addFsInfoUnalloc(m_img_info, *curFsDbInfo) == TSK_ERR){
+                    allFsProcessRet = TSK_ERR;
+                }
+            }    
         }
-        if (addFsInfoUnalloc(*it) == TSK_ERR)
-            allFsProcessRet = TSK_ERR;
     }
-
-    //TODO set parent_path for newly created virt dir/file hierarchy for consistency
-
     return allFsProcessRet;
 }
+
 
 /**
 * Process each volume in the database and add its unallocated sectors to virtual files. 

--- a/tsk/auto/db_sqlite.cpp
+++ b/tsk/auto/db_sqlite.cpp
@@ -32,7 +32,7 @@ using std::for_each;
 TskDbSqlite::TskDbSqlite(const char* a_dbFilePathUtf8, bool a_blkMapFlag)
     : TskDb(a_dbFilePathUtf8, a_blkMapFlag)
 {
-    strncpy(m_dbFilePathUtf8, a_dbFilePathUtf8, 1024);
+    snprintf(m_dbFilePathUtf8, 1024, "%s", a_dbFilePathUtf8);
     m_utf8 = true;
     m_blkMapFlag = a_blkMapFlag;
     m_db = NULL;
@@ -786,15 +786,25 @@ TskDbSqlite::addPoolInfoAndVS(const TSK_POOL_INFO *pool_info, int64_t parObjId, 
         return retVal;
     }
 
+
     // Add volume system
     if (addObject(TSK_DB_OBJECT_TYPE_VS, poolObjId, vsObjId))
         return 1;
 
-    snprintf(stmt, 1024,
-        "INSERT INTO tsk_vs_info (obj_id, vs_type, img_offset, block_size) VALUES (%" PRId64 ", %d,%" PRIuDADDR ",%d)", vsObjId, TSK_VS_TYPE_APFS, pool_info->img_offset, pool_info->block_size); // TODO - offset
+    if (pool_info->ctype == TSK_POOL_TYPE_APFS){
+        snprintf(stmt, 1024,
+            "INSERT INTO tsk_vs_info (obj_id, vs_type, img_offset, block_size) VALUES (%" PRId64 ", %d,%" PRIuDADDR ",%d)", vsObjId, TSK_VS_TYPE_APFS, pool_info->img_offset, pool_info->block_size); // TODO - offset
+    }
+    #ifdef HAVE_LIBVSLVM
+    if (pool_info->ctype == TSK_POOL_TYPE_LVM){
+        snprintf(stmt, 1024,
+            "INSERT INTO tsk_vs_info (obj_id, vs_type, img_offset, block_size) VALUES (%" PRId64 ", %d,%" PRIuDADDR ",%d)", vsObjId, TSK_VS_TYPE_LVM, pool_info->img_offset, pool_info->block_size); // TODO - offset
+    }
+    #endif /* HAVE_LIBVSLVM */
 
     return attempt_exec(stmt,
         "Error adding data to tsk_vs_info table: %s\n");
+
 }
 
 /**

--- a/tsk/auto/tsk_case_db.h
+++ b/tsk/auto/tsk_case_db.h
@@ -159,6 +159,12 @@ class TskAutoDb:public TskAuto {
     std::map<int64_t, int64_t> m_poolOffsetToParentId;
     std::map<int64_t, int64_t> m_poolOffsetToVsId;
 
+    // Cached objects
+    vector<TSK_DB_FS_INFO> m_savedFsInfo;    
+    vector<TSK_DB_VS_INFO> m_savedVsInfo;
+    vector<TSK_DB_VS_PART_INFO> m_savedVsPartInfo;
+    vector<TSK_DB_OBJECT> m_savedObjects;
+
     // prevent copying until we add proper logic to handle it
     TskAutoDb(const TskAutoDb&);
     TskAutoDb & operator=(const TskAutoDb&);
@@ -193,13 +199,14 @@ class TskAutoDb:public TskAuto {
     int md5HashAttr(unsigned char md5Hash[16], const TSK_FS_ATTR * fs_attr);
     TSK_RETVAL_ENUM addUnallocatedPoolBlocksToDb(size_t & numPool);
     static TSK_WALK_RET_ENUM fsWalkUnallocBlocksCb(const TSK_FS_BLOCK *a_block, void *a_ptr);
-    TSK_RETVAL_ENUM addFsInfoUnalloc(const TSK_DB_FS_INFO & dbFsInfo);
+    TSK_RETVAL_ENUM addFsInfoUnalloc(const TSK_IMG_INFO*  curImgInfo, const TSK_DB_FS_INFO & dbFsInfo);
     TSK_RETVAL_ENUM addUnallocFsSpaceToDb(size_t & numFs);
     TSK_RETVAL_ENUM addUnallocVsSpaceToDb(size_t & numVsP);
     TSK_RETVAL_ENUM addUnallocImageSpaceToDb();
     TSK_RETVAL_ENUM addUnallocSpaceToDb();
     TSK_RETVAL_ENUM addUnallocBlockFileInChunks(uint64_t byteStart, TSK_OFF_T totalSize, int64_t parentObjId, int64_t dataSourceObjId);
-
+    TSK_RETVAL_ENUM getVsPartById(int64_t objId, TSK_VS_PART_INFO & vsPartInfo);
+    TSK_RETVAL_ENUM getVsByFsId(int64_t objId, TSK_DB_VS_INFO & vsDbInfo);
 };
 
 

--- a/tsk/auto/tsk_db_sqlite.h
+++ b/tsk/auto/tsk_db_sqlite.h
@@ -31,6 +31,8 @@
 using std::map;
 using std::vector;
 
+
+
 /** \internal
  * C++ class that wraps the database internals. 
  */

--- a/tsk/pool/lvm_pool_compat.cpp
+++ b/tsk/pool/lvm_pool_compat.cpp
@@ -18,7 +18,7 @@
 #include <stdexcept>
 
 /**
- * Get error string from libvslvm and make buffer empty if that didn't work. 
+ * Get error string from libvslvm and make buffer empty if that didn't work.
  * @returns 1 if error message was not set
  */
 static uint8_t getError(libvslvm_error_t *vslvm_error, char error_string[512])
@@ -145,9 +145,6 @@ lvm_logical_volume_img_read(TSK_IMG_INFO * img_info, TSK_OFF_T offset, char *buf
     IMG_POOL_INFO *pool_img_info = (IMG_POOL_INFO *)img_info;
     libvslvm_error_t *vslvm_error = NULL;
 
-    // Commented: offset is already relative (0) to the img_info, that is relative to the volume
-    //// correct the offset to be relative to the start of the logical volume
-    //offset -= pool_img_info->pool_info->img_offset;
 
     if (tsk_verbose) {
         tsk_fprintf(stderr, "lvm_logical_volume_img_read: offset: %" PRIdOFF " read len: %" PRIuSIZE ".\n",

--- a/tsk/pool/lvm_pool_compat.cpp
+++ b/tsk/pool/lvm_pool_compat.cpp
@@ -145,8 +145,9 @@ lvm_logical_volume_img_read(TSK_IMG_INFO * img_info, TSK_OFF_T offset, char *buf
     IMG_POOL_INFO *pool_img_info = (IMG_POOL_INFO *)img_info;
     libvslvm_error_t *vslvm_error = NULL;
 
-    // correct the offset to be relative to the start of the logical volume
-    offset -= pool_img_info->pool_info->img_offset;
+    // Commented: offset is already relative (0) to the img_info, that is relative to the volume
+    //// correct the offset to be relative to the start of the logical volume
+    //offset -= pool_img_info->pool_info->img_offset;
 
     if (tsk_verbose) {
         tsk_fprintf(stderr, "lvm_logical_volume_img_read: offset: %" PRIdOFF " read len: %" PRIuSIZE ".\n",

--- a/tsk/vs/mm_open.c
+++ b/tsk/vs/mm_open.c
@@ -225,6 +225,7 @@ tsk_vs_open(TSK_IMG_INFO * img_info, TSK_DADDR_T offset,
         case TSK_VS_TYPE_GPT:
             return tsk_vs_gpt_open(img_info, offset);
         case TSK_VS_TYPE_APFS: // Not supported yet
+        case TSK_VS_TYPE_LVM: // Not supported yet
         case TSK_VS_TYPE_UNSUPP:
         default:
             tsk_error_reset();

--- a/tsk/vs/tsk_vs.h
+++ b/tsk/vs/tsk_vs.h
@@ -54,6 +54,7 @@ extern "C" {
         TSK_VS_TYPE_MAC = 0x0008,       ///< Mac partition table
         TSK_VS_TYPE_GPT = 0x0010,       ///< GPT partition table
         TSK_VS_TYPE_APFS =  0x0020,     ///< APFS 
+        TSK_VS_TYPE_LVM =  0x0030,     ///< LVM
         TSK_VS_TYPE_DBFILLER = 0x00F0,  ///< fake partition table type for loaddb (for images that do not have a volume system)
         TSK_VS_TYPE_UNSUPP = 0xffff,    ///< Unsupported
     } TSK_VS_TYPE_ENUM;


### PR DESCRIPTION
PR to add support to unallocated space on tsk_loaddb and sleuthkitJNI.

I did some changes on the code and used some already implemented logical structures that were not being used at the moment.

I used the possibility to LVM be VS and Pool, like APFS, and used the two implementations on sleuthkit code and db to achieve the goal.

auto_db and auto_db_java, that do similar things on the automated ingestion process, were partially "synchronized" to support unallocated space on the automated ingestion process.

I didn't test the full extent of possibilities, only a test dd image was used. Need more testing on more pools, vs, volumes and fs scenarios.

UPDATE: I updated the code as suggested on pull request comments (https://github.com/joachimmetz/sleuthkit/pull/1). The suggestions seemed to be correct. 